### PR TITLE
fixes broken db update due to ilDB checks

### DIFF
--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -48,7 +48,8 @@ $fields = array(
 	),
 	'documents_generated' => array(
 		'notnull' => false,
-		'type'    => 'int'
+		'type'    => 'integer',
+		'length'  => '4'
 	),
 );
 if(!$ilDB->tableExists('pl_scas_user_packages'))


### PR DESCRIPTION
DB-Update vor der Aktivierung des Plugins schlägt momentan fehl, da "int" kein in ilDB unterstützer Typ ist.