### PR TITLE
Added require for tcpdf to fix "TCPDF class not found" error

### DIFF
--- a/classes/pdf/class.ilScanAssessmentPdfAppendMarker.php
+++ b/classes/pdf/class.ilScanAssessmentPdfAppendMarker.php
@@ -4,11 +4,13 @@ ilScanAssessmentPlugin::getInstance()->includeClass('pdf/class.ilScanAssessmentP
 ilScanAssessmentPlugin::getInstance()->includeClass('pdf/class.ilScanAssessmentPdfHeaderForm.php');
 ilScanAssessmentPlugin::getInstance()->includeClass('scanner/geometry/class.ilScanAssessmentVector.php');
 
+require_once 'Services/PDFGeneration/classes/tcpdf/tcpdf.php';
+
 /**
  * Class ilPDFAppendMarker
  * @author Guido Vollbach <gvollbach@databay.de>
  */
-class ilPDFAppendMarker extends TCPDF{
+class ilPDFAppendMarker extends TCPDF {
 
 	
 	/**


### PR DESCRIPTION
Mit der aktuellsten Version bekomme ich, sobald ich in den Plugin-Bereich gehe, folgenden Fehler:

```Fatal error: Class 'TCPDF' not found in /var/www/html/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/ScanAssessment/classes/pdf/class.ilScanAssessmentPdfAppendMarker.php on line 11
```

Diese Änderung behebt das.