### PR TITLE
issue an error if pdf generation is triggered with a non-positive number

### DIFF
--- a/classes/controller/class.ilScanAssessmentUserPackagesPdfGUI.php
+++ b/classes/controller/class.ilScanAssessmentUserPackagesPdfGUI.php
@@ -180,8 +180,13 @@ class ilScanAssessmentUserPackagesPdfGUI extends ilScanAssessmentUserPackagesGUI
 		}
 		else
 		{
-			$pdf_builder->createNonPersonalisedPdf($this->configuration->getCountDocuments());
-			$this->redirectAndInfo($this->getCoreController()->getPluginObject()->txt('scas_pdfs_created'));
+		    $number = $this->configuration->getCountDocuments();
+		    if ($number > 0) {
+                $pdf_builder->createNonPersonalisedPdf($number);
+                $this->redirectAndInfo($this->getCoreController()->getPluginObject()->txt('scas_pdfs_created'));
+            } else {
+                $this->redirectAndInfo($this->getCoreController()->getPluginObject()->txt('scas_pdfs_zero_count'));
+            }
 		}
 	}
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -52,6 +52,7 @@ scas_complete_download_info#:#Sammeldownload
 scas_download_as_flag#:#Fahne
 scas_download_as_zip#:#Zip-Archiv
 scas_pdfs_created#:#PDF Erzeugung abgeschlossen.
+scas_pdfs_zero_count#:#Bitte konfigurieren Sie im Tab "Einstellungen" eine gültige PDF-Anzahl.
 scas_create_demo_pdf#:#Demo PDF erzeugen
 scas_steps#:#Schritt
 scas_is_activated#:#Ist aktiviert

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -52,6 +52,7 @@ scas_complete_download_info#:#Complete Download
 scas_download_as_flag#:#Flag
 scas_download_as_zip#:#Zip
 scas_pdfs_created#:#PDF creation done.
+scas_pdfs_zero_count#:#Please configure a valid PDF count in the Setting tab.
 scas_create_demo_pdf#:#Create Demo PDF
 scas_steps#:#Steps
 scas_steps#:#Position


### PR DESCRIPTION
Ausgabe eines Fehlers, wenn "Anzahl" nicht konfiguriert (leer) oder 0 ist. Ich finde das ganz hilfreich, weil sonst bei "Create PDFs" einfach gar nichts passiert und man nicht weiß, was man falsch gemacht hat.