### PR TITLE
small improvements to revision UI

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -115,7 +115,10 @@ scas_disable_manual_scan_no_cron_info#:#Der ScanAssessmentCron ist nicht install
 scas_least_one_participant#:#Es muss mindestens ein Teilnehmer eingetragen sein.
 scas_scan#:#Scan
 scas_scan_revision#:#Revision
-scas_checkbox_revision#:#Checkbox Revision
+scas_checkbox_revision_todo#:#Offene Revisionen
+scas_checkbox_revision_done#:#Abgeschlossene Revisionen
+scas_revision_show_all_todo#:#Revisionen anzeigen
+scas_revision_hide_all_todo#:#Revisionen verbergen
 scas_found_elements#:#Gefundene Elemente
 scas_revision_done#:#Revision abgeschlossen
 scas_revision_done_spf#:#Revision für PDF %s abgeschlossen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -116,7 +116,10 @@ scas_disable_manual_scan_no_cron_info#:#The ScanAssessmentCron is not installed 
 scas_least_one_participant#:#At least one participant is needed.
 scas_scan#:#Scan
 scas_scan_revision#:#Revision
-scas_checkbox_revision#:#Checkbox Revision
+scas_checkbox_revision_todo#:#Unreviewed Revisions
+scas_checkbox_revision_done#:#Completed Revisions
+scas_revision_show_all_todo#:#Show Revisions
+scas_revision_hide_all_todo#:#Hide Revisions
 scas_found_elements#:#Found Elements
 scas_revision_done#:#Revision done
 scas_revision_done_spf#:#Revision for PDF %s done


### PR DESCRIPTION
Das ist ein Vorschlag, das Revision-GUI ein wenig einfacher zu machen.

Erstens werden abgearbeitete und noch offene Revisionen in zwei verschiedene Akkordeons gepackt, so dass es einfacher ist, die noch offenen sequentiell abzuarbeiten. Außerdem lassen sich mit zwei neuen Buttons alle noch offenen Revisionen öffnen, so dass man sie sehr einfach durchgehen kann, oder jedesmal jedes Item einzeln öffnen zu müssen.

Hier zwei Screenshots, damit man sich das vorstellen kann:

<img width="820" alt="rev0" src="https://cloud.githubusercontent.com/assets/25431384/23172601/95ea64c0-f856-11e6-8f69-ff432e50226c.png">

<img width="822" alt="rev1" src="https://cloud.githubusercontent.com/assets/25431384/23172605/9972d366-f856-11e6-8518-ae1f96ff1464.png">
