### PR TITLE
Better messages for missing TIFF support

### DIFF
--- a/classes/class.ilScanAssessmentConfigGUI.php
+++ b/classes/class.ilScanAssessmentConfigGUI.php
@@ -170,8 +170,11 @@ class ilScanAssessmentConfigGUI extends ilPluginConfigGUI
 
         if(!class_exists(Imagick))
         {
+            $tiff_support->setInfo($this->getPluginObject()->txt('scas_tiff_no_imagemagick_info'));
             $tiff_support->setDisabled(true);
+            $tiff_dpi_minimum->setInfo($this->getPluginObject()->txt('scas_tiff_no_imagemagick_info'));
             $tiff_dpi_minimum->setDisabled(true);
+            $tiff_dpi_maximum->setInfo($this->getPluginObject()->txt('scas_tiff_no_imagemagick_info'));
             $tiff_dpi_maximum->setDisabled(true);
         }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -146,6 +146,7 @@ scas_none_shuffle#:#Keine Randomisierung
 scas_non_conform_files_found#:#In folgenden Dateien konnten keine Marker gefunden werden:
 scas_not_for_this_test#:#Folgenden Dateien gehören nicht zu diesem Test:
 scas_internal_error#:#Ein unvorhergesehener Fehler hat den Vorgang unterbrochen. Details finden Sie in den ScanAssessment Plugin Logdateien.
+scas_tiff_no_imagemagick_info#:#TIFF-Unterstützung ist nicht verfügbar, da kein PHP-ImageMagick installiert ist.
 scas_tiff_enabled#:#TIFF erlauben
 scas_tiff_enabled_info#:#Erlaubt das Hochladen gescannter Bögen als TIFF.
 scas_tiff_dpi_minimum#:#Minimaler DPI-Wert für TIFF-Verarbeitung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -146,6 +146,7 @@ scas_none_shuffle#:#No shuffle
 scas_non_conform_files_found#:#In these files where no markers found:
 scas_not_for_this_test#:#These files do not belong to this test:
 scas_internal_error#:#An unexpected error interrupted the operation. Please consult the ScanAssessment Plugin log files.
+scas_tiff_no_imagemagick_info#:#TIFF support is unavailable as PHP ImageMagick support is not installed.
 scas_tiff_enabled#:#Enable TIFF support
 scas_tiff_enabled_info#:#Allows scanned images to be uploaded as TIFFs.
 scas_tiff_dpi_minimum#:#Minimal DPI value for TIFF processing


### PR DESCRIPTION
Now displays proper info messages if TIFF support is disabled due to missing ImageMagick packages