### PR TITLE
fixes uninitialized $this->path_to_done

### DIFF
--- a/classes/scanner/class.ilScanAssessmentScanProcess.php
+++ b/classes/scanner/class.ilScanAssessmentScanProcess.php
@@ -347,6 +347,10 @@ class ilScanAssessmentScanProcess
 				$scan_answer_object = $this->detectAnswers($marker, $qr_pos, $log, $qr_code);
 				$this->processAnswers($scan_answer_object, $qr_code, $scanner);
 			}
+			else
+			{
+				$this->getAnalysingFolder();
+			}
 			if($qr_code != false || !$not_cropped)
 			{
 				$done = $this->path_to_done . '/' . $entry;


### PR DESCRIPTION
Im Fall `$not_cropped == false` läuft der Code unten in einen Fall, wo `$this->path_to_done` nicht intialisiert ist (leer), wodurch ein Pfad der Form `/xyz.png` entsteht, was beim anschließenden file move zu einem Zugriffsfehler führt. Bin mir nicht sicher, ob dies die richtige Fehlerbehebung ist, in jedem Falle sollte `$this->path_to_done` doch wohl immer initialisiert sein; mglw. wäre ein lazy getter hier sauberer?