### PR TITLE
fixes incorrect analysis with paletted input image types like png, gif

### DIFF
--- a/classes/scanner/imageWrapper/class.ilScanAssessmentGDWrapper.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentGDWrapper.php
@@ -26,14 +26,28 @@ class ilScanAssessmentGDWrapper implements ilScanAssessmentImageWrapper
 		}
 		else if($path_parts['extension'] == 'png')
 		{
-			$img = imagecreatefrompng($fn);
-		}
+			$img = self::toTrueColor(imagecreatefrompng($fn));
+        }
 		else if($path_parts['extension'] == 'gif')
 		{
-			$img = imagecreatefromgif($fn);
+			$img = self::toTrueColor(imagecreatefromgif($fn));
 		}
+		else
+        {
+            throw new ilException(sprintf(
+                'Unsupported image file type %s', $path_parts['extension']));
+        }
 		$this->setImage($img);
 	}
+
+    private static function toTrueColor($img)
+    {
+        $width = imagesx($img);
+        $height = imagesy($img);
+        $truecolor = imagecreatetruecolor($width, $height);
+        imagecopy($truecolor, $img, 0, 0, 0, 0, $width, $height);
+        return $truecolor;
+    }
 
 	/**
 	 * @return mixed


### PR DESCRIPTION
Werden palettierte Bilder wie PNG oder GIF als Eingabe geliefert (wie sie auch als Ergebnis von einbittigen TIFFs entstehen), versagt die Analyse, d.h. auf keinem der Bilder werden Marker erkannt. Offenbar schlägt in diesen Fällen das Auslesen der Pixelwerte schief (mglw. weil statt RGB-Werten Palettenindizes geliefert werden; dies ist nur eine Vermutung, nicht verifiziert).

Diese Änderung behebt das Problem, indem PNGs und GIFs grundsätzlich immer in TrueColor-Bilder umgewandelt werden. Dadurch funktioniert die Analysephase auch bei einbittigen TIFFS und palettierten PNGs und GIFs.