### PR TITLE
fixes InvalidArgumentException error

### DIFF
--- a/libs/php-qrcode-detector-decoder/lib/qrcode/decoder/Version.php
+++ b/libs/php-qrcode-detector-decoder/lib/qrcode/decoder/Version.php
@@ -110,7 +110,7 @@ class Version
         }
         try {
             return self::getVersionForNumber(($dimension - 17) / 4);
-        } catch (InvalidArgumentException $ignored) {
+        } catch (\InvalidArgumentException $ignored) {
             throw FormatException::getFormatInstance();
         }
     }
@@ -118,7 +118,7 @@ class Version
     public  static function getVersionForNumber($versionNumber)
     {
         if ($versionNumber < 1 || $versionNumber > 40) {
-            throw new InvalidArgumentException();
+            throw new \InvalidArgumentException();
         }
         if(!self::$VERSIONS){
 


### PR DESCRIPTION
Ein Fehler in der QR-Bibliothek, der sich - sehr sporadisch - wie folgt äußert:

```PHP Fatal error:  Class 'Zxing\\Qrcode\\Decoder\\InvalidArgumentException' not found in /var/www/html/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/ScanAssessment/libs/php-qrcode-detector-decoder/lib/qrcode/decoder/Version.php on line 121, referer: http://localhost:8080/ilias.php?ref_id=68&fallbackCmd=ilScanAssessmentScanGUI.saveForm&rtoken=d498a7f2101dd868b9e615bfd7b90323&isSaCmd=1&cmd=post&cmdClass=ilscanassessmentuihookgui&cmdNode=yg:r4&baseClass=iluipluginroutergui```