### PR TITLE
More robust border case handling for checkbox rectangle detection

### DIFF
--- a/classes/scanner/class.ilScanAssessmentCheckBoxElement.php
+++ b/classes/scanner/class.ilScanAssessmentCheckBoxElement.php
@@ -172,9 +172,11 @@ class ilScanAssessmentCheckBoxElement
 		return new ilScanAssessmentArea($total, $white, $black);
 	}
 
-	protected function detectBox($im, $x, $y, $threshold)
+	protected function detectBox($im, $x, $y, $size, $threshold)
 	{
-		while(true)
+	    $x0 = $x;
+
+		while($x - $x0 < $size[0] / 2)
 		{
 			// echo "@" . $x . ", " . $y . "<br>";
 
@@ -184,7 +186,8 @@ class ilScanAssessmentCheckBoxElement
 				break;
 			}
 
-			$pixels = new ilScanAssessmentCheckBoxAnalyser($im, $x, $y, $threshold, $this->image_helper);
+			$pixels = new ilScanAssessmentCheckBoxAnalyser(
+			    $im, $x, $y, $size, $threshold, $this->image_helper);
 
 			$r = $pixels->detectRectangle();
 			if($r)
@@ -220,7 +223,10 @@ class ilScanAssessmentCheckBoxElement
 
 		$center_x = ($this->getLeftTop()->getX() + $this->getRightBottom()->getX()) / 2;
 		$center_y = ($this->getLeftTop()->getY() + $this->getRightBottom()->getY()) / 2;
-		$box      = $this->detectBox($im, $center_x, $center_y, 100);
+		$size     = array(
+		    $this->getRightBottom()->getX() - $this->getLeftTop()->getX(),
+            $this->getRightBottom()->getY() - $this->getLeftTop()->getY());
+		$box      = $this->detectBox($im, $center_x, $center_y, $size, 100);
 		if($box)
 		{
 			list($x0, $y0, $x1, $y1) = $box;

--- a/classes/scanner/imageWrapper/class.ilScanAssessmentLineDetector.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentLineDetector.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Class ilScanAssessmentLineDetector
+ */
+abstract class ilScanAssessmentLineDetector
+{
+    /**
+     * @var
+     */
+    protected $threshold;
+
+    /**
+     * the relative of black pixels on a line so that it
+     * is still detected as a line.
+     * @var
+     */
+    protected $coverage;
+
+    /**
+     * @var ilScanAssessmentImageWrapper
+     */
+    protected $img_helper;
+
+    public function __construct($img_helper, $threshold)
+    {
+        $this->img_helper = $img_helper;
+        $this->threshold = $threshold;
+        $this->coverage = 0.95;
+    }
+
+    /**
+     * @param $pixel
+     * @param $k0
+     * @param $k1
+     * @return bool
+     */
+    abstract protected function test($pixel, $k0, $k1);
+
+    /**
+     * @param $x0
+     * @param $x1
+     * @param $y
+     * @return bool
+     */
+    public function horizontal($x0, $x1, $y)
+    {
+        $pixel = function($x) use ($y)
+        {
+            return $this->img_helper->getGrey(new ilScanAssessmentPoint($x, $y));
+        };
+
+        return $this->test($pixel, $x0, $x1);
+    }
+
+    /**
+     * @param $x
+     * @param $y0
+     * @param $y1
+     * @return bool
+     */
+    public function vertical($x, $y0, $y1)
+    {
+        $pixel = function($y) use ($x)
+        {
+            return $this->img_helper->getGrey(new ilScanAssessmentPoint($x, $y));
+        };
+
+        return $this->test($pixel, $y0, $y1);
+    }
+}

--- a/classes/scanner/imageWrapper/class.ilScanAssessmentPotentialLineDetector.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentPotentialLineDetector.php
@@ -1,0 +1,41 @@
+<?php
+ilScanAssessmentPlugin::getInstance()->includeClass('scanner/imageWrapper/class.ilScanAssessmentLineDetector.php');
+
+/**
+ * Class ilScanAssessmentPotentialLineDetector
+ *
+ * This is a relaxed check (as compared to ReliableLineDetector). it allows
+ * borders on both sides of a segment. given a coverage, detects if a segment
+ * contains a sub segment satisfying the coverage, such that the sub segment
+ * is at least 1/4 times the full segment's length.
+ *
+ */
+class ilScanAssessmentPotentialLineDetector extends ilScanAssessmentLineDetector
+{
+    protected function test($pixel, $k0, $k1)
+    {
+        $threshold = $this->threshold;
+        $coverage = $this->coverage;
+
+        $n = 0;
+        $p = array();
+        $l = 0;
+        for($k = $k0; $k <= $k1; $k++)
+        {
+            $d = $pixel($k) < $threshold ? 1 : 0;
+            $n += $d;
+            array_push($p, $d);
+
+            while(count($p) > 0 && $n / (float)count($p) < $coverage)
+            {
+                $d = array_shift($p);
+                $n -= $d;
+            }
+
+            $l = max($l, count($p));
+        }
+
+        $total = $k1 - $k0 + 1;
+        return $l > $total / 4.0;
+    }
+}

--- a/classes/scanner/imageWrapper/class.ilScanAssessmentReliableLineDetector.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentReliableLineDetector.php
@@ -1,0 +1,37 @@
+<?php
+ilScanAssessmentPlugin::getInstance()->includeClass('scanner/imageWrapper/class.ilScanAssessmentLineDetector.php');
+
+/**
+ * Class ilScanAssessmentReliableLineDetector
+ */
+class ilScanAssessmentReliableLineDetector extends ilScanAssessmentLineDetector
+{
+    protected function test($pixel, $k0, $k1)
+    {
+        $threshold = $this->threshold;
+        $coverage = $this->coverage;
+
+        $total = (float)($k1 - $k0 + 1);
+
+        $n = 0;
+        for($k = $k0; $k <= $k1; $k++)
+        {
+            if($pixel($k) < $threshold)
+            {
+                $n++;
+            }
+            else
+            {
+                // early exit: even if all remaining pixels turn
+                // out to be good, can the coverage be reached?
+                $r = $k1 - $k;
+                if(($n + $r) / $total < $coverage)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return $n / $total >= $coverage;
+    }
+}


### PR DESCRIPTION
This handles all border cases that occured in my tests now (namely checkbox marks that exit the checkbox rectangle on three or more sides and checkbox marks that are so large that they touch a neighbour checkbox).