### PR TITLE
make blackness level of checkbox calculation more resilient to noise …

### DIFF
--- a/classes/class.ilScanAssessmentGlobalSettings.php
+++ b/classes/class.ilScanAssessmentGlobalSettings.php
@@ -59,12 +59,12 @@ class ilScanAssessmentGlobalSettings
 	/**
 	 * @var float
 	 */
-	protected $min_marked_area = 0.35;
+	protected $min_marked_area = 0.1;
 
 	/**
 	 * @var float
 	 */
-	protected $marked_area_checked = 0.45;
+	protected $marked_area_checked = 0.2;
 
 	/**
 	 * @var float

--- a/classes/scanner/imageWrapper/class.ilScanAssessmentLineDetector.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentLineDetector.php
@@ -22,11 +22,11 @@ abstract class ilScanAssessmentLineDetector
      */
     protected $img_helper;
 
-    public function __construct($img_helper, $threshold)
+    public function __construct($img_helper, $threshold, $coverage = 0.95)
     {
         $this->img_helper = $img_helper;
         $this->threshold = $threshold;
-        $this->coverage = 0.95;
+        $this->coverage = $coverage;
     }
 
     /**


### PR DESCRIPTION
Dies verbessert nach meinen Tests die Erkennungshäufigkeit von Checkboxen, indem die Pixel des Randes nicht mehr für die Berechnung der Schwärze der Checkbox beachtet werden. Dies hat zur Folge, dass die Schwellwerte sinken, da sie nun nur das Checkbox-Innere ohne Rand messen. Siehe auch https://github.com/DatabayAG/ScanAssessment/issues/30.