### PR TITLE
Even better exact marker detection

### DIFF
--- a/classes/scanner/imageWrapper/class.ilScanAssessmentRegion.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentRegion.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * Class ilScanAssessmentRegion
+ *
+ * Describes a contiguous region (i.e. a set of pixels connected by the
+ * definition of blackness with respect to a given threshold).
+ */
+class ilScanAssessmentRegion
+{
+    /**
+     * @var array
+     */
+    private $pixels;
+
+    /**
+     * ilScanAssessmentRegion constructor.
+     *
+     * @param ilScanAssessmentImageWrapper $image
+     * @param ilScanAssessmentPoint $p
+     * @param int $threshold
+     */
+
+    public function __construct($image, $p, $threshold)
+    {
+        // essentially a flood fill that detects all black marker pixels.
+
+        $x = $p->getX();
+        $y = $p->getY();
+        $pixels = array();
+
+        $stack = array(array($x, $y));
+
+        array_push($stack, array($x - 1, $y - 1));
+        array_push($stack, array($x - 1, $y + 1));
+        array_push($stack, array($x + 1, $y - 1));
+        array_push($stack, array($x + 1, $y + 1));
+
+        $w = $image->getImageSizeX();
+        $h = $image->getImageSizeY();
+
+        while(count($stack) > 0)
+        {
+            list($x, $y) = array_pop($stack);
+
+            if($x < 0 || $y < 0 || $x >= $w || $y >= $h)
+            {
+                continue;
+            }
+
+            $coordinates = $x . '/' . $y;
+
+            if(isset($pixels[$coordinates]))
+            {
+                continue;
+            }
+
+            if($image->getGrey(new ilScanAssessmentPoint($x, $y)) < $threshold) // black?
+            {
+                $pixels[$coordinates] = true;
+                array_push($stack, array($x + 1, $y));
+                array_push($stack, array($x - 1, $y));
+                array_push($stack, array($x, $y + 1));
+                array_push($stack, array($x, $y - 1));
+            }
+        }
+
+        $this->pixels = $pixels;
+    }
+
+    /**
+     * @return generator a generator of all coordinate pairs in this region.
+     */
+    public function coordinates()
+    {
+        foreach(array_keys($this->pixels) as $xy)
+        {
+            list($x, $y) = explode('/', $xy);
+            yield array(intval($x), intval($y));
+        }
+    }
+
+    /**
+     * @return ilScanAssessmentPoint|bool centre of this region or false, if there are no pixels.
+     */
+    public function centre()
+    {
+        $n = 0;
+
+        $x = 0;
+        $y = 0;
+
+        foreach($this->coordinates() as $xy)
+        {
+            $x += $xy[0];
+            $y += $xy[1];
+            $n++;
+        }
+
+        if($n > 0)
+        {
+            return new ilScanAssessmentPoint($x / $n, $y / $n);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
+     * Compute the bounding box of $this->pixels.
+     *
+     * @return array|bool bounding box of this region or false, if there are no pixels.
+     */
+    public function bbox()
+    {
+        $minX = PHP_INT_MAX;
+        $minY = PHP_INT_MAX;
+        $maxX = PHP_INT_MIN;
+        $maxY = PHP_INT_MIN;
+        $n = 0;
+
+        foreach($this->coordinates() as $xy)
+        {
+            list($x, $y) = $xy;
+            $minX = min($minX, $x);
+            $minY = min($minY, $y);
+            $maxX = max($maxX, $x);
+            $maxY = max($maxY, $y);
+            $n++;
+        }
+
+        if($n > 0)
+        {
+            return array($minX, $minY, $maxX, $maxY);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @return array the coordinate of the rightmost pixel in this region.
+     */
+    public function rightmost()
+    {
+        $x = PHP_INT_MIN;
+        $y = 0;
+
+        foreach($this->coordinates() as $pixel)
+        {
+            if($pixel[0] > $x)
+            {
+                list($x, $y) = $pixel;
+            }
+        }
+
+        return array($x, $y);
+    }
+
+    public function size()
+    {
+        return count($this->pixels);
+    }
+}


### PR DESCRIPTION
Behebt konkret den Fehler, der im Rahmen von https://github.com/DatabayAG/ScanAssessment/issues/18 zunächst für einen Fehler in `imagerotate` in GD gehalten wurde, da er sich durch Wahl einer anderen Interpolationsmethode (nicht `IMG_BILINEAR_FIXED`) beheben ließ.

Tatsächlich handelt es sich bei genauer Analyse aber um keinen Fehler in `imagerotate`, das auch bei `IMG_BILINEAR_FIXED` absolut sinnvolle Ergebnisse liefert (wenn auch offenbar in verschiedenen GD-Versionen leicht unterschiedliche). Vielmehr liegt dem Fehler offenbar eine Anfälligkeit in `ilScanAssessmentMarkerDetection::detectExactMarkerPosition` zugrunde, wo durch einzelne andere Pixel (wie bei einer anderen Interpolationsmethode) ein völlig anderes Ergebnis geliefert wurde.

In der bisherigen Implementierung wird nach dem ersten hellen Pixel außerhalb des Markers gesucht, um so den Marker einzugrenzen. Nun wird, ausgehend von der vermuteten Mitte des Markers, nach einer schwarzen Region einer bestimmten Größe gesucht, die dann für die Berechnung des Markerzentrums genutzt wird. Dieser Ansatz ist robuster, da garantiert alle Pixel des Markers erfasst werden und durch eine Zentrumsberechnung miteinbezogen werden.

Der PR ist relativ groß, da die Methode `gatherPixels` zusammen mit mehreren anderen Methoden in eine neue Klasse `ilScanAssessmentRegion` ausgelagert wurde, da die Funktionalität nun sowohl von der Checkboxerkennung als auch von der Markererkennung genutzt wird.