### PR TITLE
consistent black border trim for both checkbox detection algorithms

### DIFF
--- a/classes/scanner/imageWrapper/class.ilScanAssessmentCheckBoxAnalyser.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentCheckBoxAnalyser.php
@@ -59,8 +59,6 @@ class ilScanAssessmentCheckBoxAnalyser
      */
     private $potential_line;
 
-    private $border_line;
-
 	/**
 	 * ilScanAssessmentCheckBoxAnalyser constructor.
 	 * @param $image
@@ -83,7 +81,6 @@ class ilScanAssessmentCheckBoxAnalyser
 
         $this->reliable_line = new ilScanAssessmentReliableLineDetector($image_helper, $threshold);
         $this->potential_line = new ilScanAssessmentPotentialLineDetector($image_helper, $threshold);
-        $this->border_line = new ilScanAssessmentReliableLineDetector($image_helper, $threshold, 0.4);
     }
 
     /**
@@ -379,38 +376,6 @@ class ilScanAssessmentCheckBoxAnalyser
 
             if($faulty === false)
             {
-                // removing borders seems to make detection thresholds more resilient to noise.
-                // ignoring the black borders of a checkbox and using only inner pixels for
-                // calculating the blackness ratio of a checkbox, is a good idea as the border
-                // pixels might be jagged or contain varying noise; thus, one empty checkbox's
-                // blackness ratio might be higher than another empty one's due to slightly
-                // different border pixels and thus skew the detected blackness levels.
-
-                $s = 0.1; // maximum factor to remove
-                $max_dx = intval($s * ($x1 - $x0));
-                $max_dy = intval($s * ($y1 - $y0));
-                $max_x0 = $x0 + $max_dx;
-                $min_x1 = $x1 - $max_dx;
-                $max_y0 = $y0 + $max_dy;
-                $min_y1 = $y1 - $max_dy;
-
-                while($y0 < $max_y0 && $this->border_line->horizontal($x0, $x1, $y0))
-                {
-                    $y0++;
-                }
-                while($y1 > $min_y1 && $this->border_line->horizontal($x0, $x1, $y1))
-                {
-                    $y1--;
-                }
-                while($x0 < $max_x0 && $this->border_line->vertical($x0, $y0, $y1))
-                {
-                    $x0++;
-                }
-                while($x1 > $min_x1 && $this->border_line->vertical($x1, $y0, $y1))
-                {
-                    $x1--;
-                }
-
                 return array($x0, $y0, $x1, $y1);
             }
 


### PR DESCRIPTION
Mit f49d041 haben wir ja eine andere Berechnung des Schwarzwerts eingeführt, nämlich eine, die versucht, die Pixels des Rahmens der Checkbox nicht miteinzubeziehen.

Das passiert momentan leider nur für den veränderten Algorithmus (ich nenne ihn mal A), und nicht für den bisherigen (sagen wir mal Algorithmus B), der ja weiterhin als Fallback zieht, wenn A nichts liefert.

Das ist insofern ein Problem, als je nachdem ob mit oder ohne Borderpixel gerechnet wird, die Schwellenwerte anders zu definieren sind, und damit, wenn B nun zieht, alles grün wird, wenn die Schwellenwerte für eine Berechnung ohne Rand gesetzt sind (nämlich sehr niedrig, z.B. 0.2 für die Erkennung einer Markierung).

Kurz gesagt zieht diese Änderung die Randentfernung an eine Stelle, wo sie sowohl für Algorithmus A als auch B angewendet wird. Dann führt ein Fallback zu B nicht zu einem Fehler.