### PR TITLE
Konstanten-Tweaks

### DIFF
--- a/classes/class.ilScanAssessmentGlobalSettings.php
+++ b/classes/class.ilScanAssessmentGlobalSettings.php
@@ -59,12 +59,12 @@ class ilScanAssessmentGlobalSettings
 	/**
 	 * @var float
 	 */
-	protected $min_marked_area = 0.1;
+	protected $min_marked_area = 0.05;
 
 	/**
 	 * @var float
 	 */
-	protected $marked_area_checked = 0.2;
+	protected $marked_area_checked = 0.15;
 
 	/**
 	 * @var float

--- a/classes/scanner/class.ilScanAssessmentCheckBoxElement.php
+++ b/classes/scanner/class.ilScanAssessmentCheckBoxElement.php
@@ -89,9 +89,8 @@ class ilScanAssessmentCheckBoxElement
 		$this->min_marked_area       = ilScanAssessmentGlobalSettings::getInstance()->getMinMarkedArea();
 		$this->marked_area_checked   = ilScanAssessmentGlobalSettings::getInstance()->getMarkedAreaChecked();
 		$this->marked_area_unchecked = ilScanAssessmentGlobalSettings::getInstance()->getMarkedAreaUnchecked();
-		
-		//Todo: fix $threshold
-        $this->border_line = new ilScanAssessmentReliableLineDetector($image_helper, $threshold, 0.4);
+
+        $this->border_line = new ilScanAssessmentReliableLineDetector($image_helper, $this->min_value_black, 0.4);
 	}
 
 	/**
@@ -234,7 +233,7 @@ class ilScanAssessmentCheckBoxElement
         $x1 = $this->getRightBottom()->getX();
         $y1 = $this->getRightBottom()->getY();
 
-        $s = 0.1; // maximum factor to remove
+        $s = 0.2; // maximum factor to remove
         $max_dx = intval($s * ($x1 - $x0));
         $max_dy = intval($s * ($y1 - $y0));
         $max_x0 = $x0 + $max_dx;


### PR DESCRIPTION
Behebt fehlenden `$threshold` bei der Erzeugung von `$this->border_line`. Dies führte wohl dazu, dass die Randentfernung nicht wirklich funktionierte.

Zu den Konstantenänderungen:

**trimBorder**

Die Hebung des `trimBorder`-Werts von 0.1 auf 0.2 erlaubt ein weitaus besseres Handling von Checkboxen, bei denen durch das Scannen Artefakte entstanden:

Erkennung vorher:

![vorher](https://cloud.githubusercontent.com/assets/25431384/26347523/25230b20-3faa-11e7-8bdd-d3e22039f975.png)

Erkennung nachher (man beachte die korrekt positionierte Box ohne Rahmen):

![nachher](https://cloud.githubusercontent.com/assets/25431384/26347533/2b8b34ba-3faa-11e7-9d79-bb8068fadb0f.png)

**marked_area_checked**

Insgesamt scheint 0.15 für die `$marked_area_checked` aus meiner Sicht ein besserer Defaultwert zu sein, da er gerade noch viele Fälle, die kein Schmutz sind, abdeckt:

Vorher:

![vorher-checkbox](https://cloud.githubusercontent.com/assets/25431384/26347756/d5408078-3faa-11e7-82b8-6ad3dd79281a.png)

Nachher:

![nachher-checkbox](https://cloud.githubusercontent.com/assets/25431384/26347763/db6172d2-3faa-11e7-83c2-1e3e06a95959.png)
