### PR TITLE
Handling großer Markierungen

### DIFF
--- a/classes/scanner/imageWrapper/class.ilScanAssessmentCheckBoxAnalyser.php
+++ b/classes/scanner/imageWrapper/class.ilScanAssessmentCheckBoxAnalyser.php
@@ -294,7 +294,7 @@ class ilScanAssessmentCheckBoxAnalyser
         {
             if(abs($this->origin[1] - $y0) < abs($this->origin[1] - $y1))
             {
-                $y1 = $this->clipBottom($this->reliable_line, $x0, $y0, $x1, $y1);
+                $y1 = $this->clipBottom($this->potential_line, $x0, $y0, $x1, $y1);
                 if ($y1 === false)
                 {
                     return false;
@@ -302,7 +302,7 @@ class ilScanAssessmentCheckBoxAnalyser
             }
             else
             {
-                $y0 = $this->clipTop($this->reliable_line, $x0, $y0, $x1, $y1);
+                $y0 = $this->clipTop($this->potential_line, $x0, $y0, $x1, $y1);
                 if ($y0 === false)
                 {
                     return false;
@@ -314,7 +314,7 @@ class ilScanAssessmentCheckBoxAnalyser
         {
             if(abs($this->origin[0] - $x0) < abs($this->origin[0] - $x1))
             {
-                $x1 = $this->clipRight($this->reliable_line, $x0, $y0, $x1, $y1);
+                $x1 = $this->clipRight($this->potential_line, $x0, $y0, $x1, $y1);
                 if ($x1 === false)
                 {
                     return false;
@@ -322,7 +322,7 @@ class ilScanAssessmentCheckBoxAnalyser
             }
             else
             {
-                $x0 = $this->clipLeft($this->reliable_line, $x0, $y0, $x1, $y1);
+                $x0 = $this->clipLeft($this->potential_line, $x0, $y0, $x1, $y1);
                 if ($x0 === false)
                 {
                     return false;


### PR DESCRIPTION
Im Zusammenhang dieses PRs kommt noch ein Issue.

Bei großen Markierungen, die den Rahmen der Checkbox auf drei oder mehr Seiten deutlich verlassen, gibt es im Moment ein Problem in `reduceRectangle` (die Suche des Rands in einer Richtung geht davon aus, dass nicht drei oder mehr Ränder initial falsch sind). Dieser PR behebt das Problem durch eine flexiblere Suche.

Die Probleme traten auf in folgendem Testset:

[URK-Scan-20170607.tif.zip](https://github.com/DatabayAG/ScanAssessment/files/1060185/URK-Scan-20170607.tif.zip)
[1495636590__0__tst_269.zip](https://github.com/DatabayAG/ScanAssessment/files/1060187/1495636590__0__tst_269.zip)

In folgender Zip-Datei sind die Ergebnisse der problematischen Seiten in obigem Testset ohne und mit dem PR dokumentiert:

[before-after.zip](https://github.com/DatabayAG/ScanAssessment/files/1060191/before-after.zip)

Hier z.B. Seite 14/1 ohne den PR (links) und mit dem PR (rechts):

![ubersicht-pr](https://user-images.githubusercontent.com/25431384/26916871-404c1390-4c2c-11e7-8ec9-e576bc247247.png)
