### PR TITLE
fixes ilDatabaseException

### DIFF
--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -391,7 +391,7 @@ if(!$ilDB->tableColumnExists('pl_scas_pdf_data', 'header_page'))
 		array(
 			'notnull'=> false,
 			'type'   => 'integer',
-			'length' => '25',
+			'length' => '4',
 			'default' => 0
 		)
 	);


### PR DESCRIPTION
Behebt Fehler bei DB-Anlage unter MariaDB/InnoDB:

[ilias.txt](https://github.com/DatabayAG/ScanAssessment/files/1276290/ilias.txt)
